### PR TITLE
Fix logout response validation

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -1539,7 +1539,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(query url.Values) erro
 	}
 
 	doc := etree.NewDocument()
-	if err := doc.ReadFromBytes(rawResponseBuf); err != nil {
+	if err := doc.ReadFromBytes(gr); err != nil {
 		retErr.PrivateErr = err
 		return retErr
 	}

--- a/service_provider.go
+++ b/service_provider.go
@@ -1547,7 +1547,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(query url.Values) erro
 	}
 
 	if err := sp.validateSignature(doc.Root()); err != nil {
-		if err != errSignatureElementNotPresent && !hasValidSignature {
+		if err != errSignatureElementNotPresent || !hasValidSignature {
 			retErr.PrivateErr = err
 			return retErr
 		}

--- a/service_provider.go
+++ b/service_provider.go
@@ -1531,11 +1531,13 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(query url.Values) erro
 		return err
 	}
 
+	hasValidSignature := false
 	if query.Get("Signature") != "" && query.Get("SigAlg") != "" {
 		if err := sp.validateQuerySig(query); err != nil {
 			retErr.PrivateErr = err
 			return retErr
 		}
+		hasValidSignature = true
 	}
 
 	doc := etree.NewDocument()
@@ -1545,8 +1547,10 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(query url.Values) erro
 	}
 
 	if err := sp.validateSignature(doc.Root()); err != nil {
-		retErr.PrivateErr = err
-		return retErr
+		if err != errSignatureElementNotPresent && !hasValidSignature {
+			retErr.PrivateErr = err
+			return retErr
+		}
 	}
 
 	var resp LogoutResponse


### PR DESCRIPTION
This PR fixes issue described in https://github.com/crewjam/saml/issues/489
It contains 2 parts:
1. Fix reading compressed XML doc.
2. Fix signature verification. The issue here is that if SAML message does not contain signature, validation fails even if signature is provided in URL query params and verified. It fixes single logout flow in case of redirect request, but I feel that it requires a bit more investigation since `validateSignature()` function is used widely in SP implementation.