### PR TITLE
Chore: Change module name to proper repo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
 linters-settings:
   goimports:
-    local-prefixes: github.com/crewjam/saml
+    local-prefixes: github.com/grafana/saml
   govet:
     disable:
       - shadow

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2015, Ross Kinder
-Copyright (c) 2025, Grafana Labs
+Copyright (c) 2015-2023, Ross Kinder
+Copyright (c) 2023-2025, Grafana Labs
 
 All rights reserved.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
 Copyright (c) 2015, Ross Kinder
+Copyright (c) 2025, Grafana Labs
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SAML
 
-[![](https://godoc.org/github.com/crewjam/saml?status.svg)](http://godoc.org/github.com/crewjam/saml)
+[![](https://godoc.org/github.com/grafana/saml?status.svg)](http://godoc.org/github.com/grafana/saml)
 
-![Build Status](https://github.com/crewjam/saml/workflows/Presubmit/badge.svg)
+![Build Status](https://github.com/grafana/saml/workflows/Presubmit/badge.svg)
 
 Package saml contains a partial implementation of the SAML standard in golang.
 SAML is a standard for identity federation, i.e. either allowing a third party to authenticate your users or allowing third parties to rely on us to authenticate their users.
@@ -54,7 +54,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/grafana/saml/samlsp"
 )
 
 func hello(w http.ResponseWriter, r *http.Request) {

--- a/duration.go
+++ b/duration.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/duration.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/duration.go
+++ b/duration.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/duration.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/duration_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/duration_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/example/idp/idp.go
+++ b/example/idp/idp.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/example/idp/idp.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package main contains an example identity provider implementation.
 package main
 

--- a/example/idp/idp.go
+++ b/example/idp/idp.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/example/idp/idp.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package main contains an example identity provider implementation.
 package main

--- a/example/idp/idp.go
+++ b/example/idp/idp.go
@@ -11,8 +11,8 @@ import (
 	"github.com/zenazn/goji"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/samlidp"
+	"github.com/grafana/saml/logger"
+	"github.com/grafana/saml/samlidp"
 )
 
 var key = func() crypto.PrivateKey {

--- a/example/service.go
+++ b/example/service.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/example/service.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // This is an example that implements a bitly-esque short link service.
 package main
 

--- a/example/service.go
+++ b/example/service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/zenazn/goji"
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/grafana/saml/samlsp"
 )
 
 var links = map[string]Link{}

--- a/example/service.go
+++ b/example/service.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/example/service.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // This is an example that implements a bitly-esque short link service.
 package main

--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/example/trivial/trivial.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package main contains an example service provider implementation.
 package main

--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/example/trivial/trivial.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package main contains an example service provider implementation.
 package main
 

--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/grafana/saml/samlsp"
 )
 
 var samlMiddleware *samlsp.Middleware

--- a/flate.go
+++ b/flate.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/flate.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/flate.go
+++ b/flate.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/flate.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crewjam/saml
+module github.com/grafana/saml
 
 go 1.19
 

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/identity_provider.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/identity_provider.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -21,8 +21,8 @@ import (
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/grafana/saml/logger"
+	"github.com/grafana/saml/xmlenc"
 )
 
 // Session represents a user session. It is returned by the

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/testsaml"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/grafana/saml/logger"
+	"github.com/grafana/saml/testsaml"
+	"github.com/grafana/saml/xmlenc"
 )
 
 type IdentityProviderTest struct {

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/identity_provider_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/identity_provider_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/logger/logger.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package logger provides a logging interface.
 package logger

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/logger/logger.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package logger provides a logging interface.
 package logger
 

--- a/metadata.go
+++ b/metadata.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/metadata.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/metadata.go
+++ b/metadata.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/metadata.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/metadata_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/metadata_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/saml.go
+++ b/saml.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/saml.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package saml contains a partial implementation of the SAML standard in golang.
 // SAML is a standard for identity federation, i.e. either allowing a third party to authenticate your users or allowing third parties to rely on us to authenticate their users.
 //

--- a/saml.go
+++ b/saml.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/saml.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package saml contains a partial implementation of the SAML standard in golang.
 // SAML is a standard for identity federation, i.e. either allowing a third party to authenticate your users or allowing third parties to rely on us to authenticate their users.

--- a/saml.go
+++ b/saml.go
@@ -11,7 +11,7 @@
 //
 // Version 0.4.0 introduces a few breaking changes to the _samlsp_ package in order to make the package more extensible, and to clean up the interfaces a bit. The default behavior remains the same, but you can now provide interface implementations of _RequestTracker_ (which tracks pending requests), _Session_ (which handles maintaining a session) and _OnError_ which handles reporting errors.
 //
-// Public fields of _samlsp.Middleware_ have changed, so some usages may require adjustment. See [issue 231](https://github.com/crewjam/saml/issues/231) for details.
+// Public fields of _samlsp.Middleware_ have changed, so some usages may require adjustment. See [issue 231](https://github.com/grafana/saml/issues/231) for details.
 //
 // The option to provide an IDP metadata URL has been deprecated. Instead, we recommend that you use the `FetchMetadata()` function, or fetch the metadata yourself and use the new `ParseMetadata()` function, and pass the metadata in _samlsp.Options.IDPMetadata_.
 //
@@ -76,7 +76,7 @@
 //	"net/http"
 //	"net/url"
 //
-//	"github.com/crewjam/saml/samlsp"
+//	"github.com/grafana/saml/samlsp"
 //
 // )
 //

--- a/saml_gen.go
+++ b/saml_gen.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/saml_gen.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 //go:generate bash -c "(cat README.md | grep -E -v '^# SAML' | sed 's|^## ||g' | sed 's|\\*\\*||g' | sed 's|^|// |g'; echo 'package saml') > saml.go"

--- a/saml_gen.go
+++ b/saml_gen.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/saml_gen.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/samlidp/memory_store.go
+++ b/samlidp/memory_store.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/memory_store.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/memory_store.go
+++ b/samlidp/memory_store.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/memory_store.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/logger"
+	"github.com/grafana/saml"
+	"github.com/grafana/saml/logger"
 )
 
 // Options represent the parameters to New() for creating a new IDP server

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/samlidp.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package samlidp a rudimentary SAML identity provider suitable for
 // testing or as a starting point for a more complex service.
 package samlidp

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/samlidp.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package samlidp a rudimentary SAML identity provider suitable for
 // testing or as a starting point for a more complex service.

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/samlidp_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/logger"
+	"github.com/grafana/saml"
+	"github.com/grafana/saml/logger"
 )
 
 type testRandomReader struct {

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/samlidp_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/service.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 // Service represents a configured SP for whom this IDP provides authentication services.

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/service.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/service_test.go
+++ b/samlidp/service_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/service_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/service_test.go
+++ b/samlidp/service_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/service_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/session.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 var sessionMaxAge = time.Hour

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/session.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/session_test.go
+++ b/samlidp/session_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/session_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/session_test.go
+++ b/samlidp/session_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/session_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/shortcut.go
+++ b/samlidp/shortcut.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/shortcut.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/shortcut.go
+++ b/samlidp/shortcut.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/shortcut.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/shortcut_test.go
+++ b/samlidp/shortcut_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/shortcut_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/shortcut_test.go
+++ b/samlidp/shortcut_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/shortcut_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/store.go
+++ b/samlidp/store.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/store.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import "errors"

--- a/samlidp/store.go
+++ b/samlidp/store.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/store.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/user.go
+++ b/samlidp/user.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/user.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/user.go
+++ b/samlidp/user.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/user.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/user_test.go
+++ b/samlidp/user_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/user_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/user_test.go
+++ b/samlidp/user_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/user_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/util.go
+++ b/samlidp/util.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/util.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlidp
 
 import (

--- a/samlidp/util.go
+++ b/samlidp/util.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/util.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlidp
 

--- a/samlidp/util.go
+++ b/samlidp/util.go
@@ -8,7 +8,7 @@ import (
 
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 func randomBytes(n int) []byte {

--- a/samlidp/util_test.go
+++ b/samlidp/util_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/util_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 //go:build go1.17
 // +build go1.17
 

--- a/samlidp/util_test.go
+++ b/samlidp/util_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlidp/util_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 //go:build go1.17
 // +build go1.17

--- a/samlsp/error.go
+++ b/samlsp/error.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 // ErrorFunction is a callback that is invoked to return an error to the

--- a/samlsp/error.go
+++ b/samlsp/error.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/error.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/error.go
+++ b/samlsp/error.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/error.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/fetch_metadata.go
+++ b/samlsp/fetch_metadata.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/fetch_metadata.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/fetch_metadata.go
+++ b/samlsp/fetch_metadata.go
@@ -12,9 +12,9 @@ import (
 	"github.com/crewjam/httperr"
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
-	"github.com/crewjam/saml/logger"
+	"github.com/grafana/saml/logger"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 // ParseMetadata parses arbitrary SAML IDP metadata.

--- a/samlsp/fetch_metadata.go
+++ b/samlsp/fetch_metadata.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/fetch_metadata.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/fetch_metadata_test.go
+++ b/samlsp/fetch_metadata_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/fetch_metadata_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/fetch_metadata_test.go
+++ b/samlsp/fetch_metadata_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/fetch_metadata_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/middleware.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/middleware.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 // Middleware implements middleware than allows a web application

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/middleware_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/middleware_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -23,8 +23,8 @@ import (
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/golden"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/testsaml"
+	"github.com/grafana/saml"
+	"github.com/grafana/saml/testsaml"
 )
 
 type MiddlewareTest struct {

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/new.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package samlsp provides helpers that can be used to protect web services using SAML.
 package samlsp

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/new.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package samlsp provides helpers that can be used to protect web services using SAML.
 package samlsp
 

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -9,7 +9,7 @@ import (
 
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 // Options represents the parameters for creating a new middleware

--- a/samlsp/new_test.go
+++ b/samlsp/new_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/new_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/new_test.go
+++ b/samlsp/new_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/new_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/request_tracker.go
+++ b/samlsp/request_tracker.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/request_tracker.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/request_tracker.go
+++ b/samlsp/request_tracker.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/request_tracker.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/request_tracker_cookie.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/request_tracker_cookie.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 var _ RequestTracker = CookieRequestTracker{}

--- a/samlsp/request_tracker_jwt.go
+++ b/samlsp/request_tracker_jwt.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 var defaultJWTSigningMethod = jwt.SigningMethodRS256

--- a/samlsp/request_tracker_jwt.go
+++ b/samlsp/request_tracker_jwt.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/request_tracker_jwt.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/request_tracker_jwt.go
+++ b/samlsp/request_tracker_jwt.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/request_tracker_jwt.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/samlsp_test.go
+++ b/samlsp/samlsp_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/samlsp_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/samlsp_test.go
+++ b/samlsp/samlsp_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/samlsp_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/session.go
+++ b/samlsp/session.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/session.go
+++ b/samlsp/session.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/session.go
+++ b/samlsp/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 // Session is an interface implemented to contain a session.

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 const defaultSessionCookieName = "token"

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session_cookie.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session_cookie.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/session_cookie_test.go
+++ b/samlsp/session_cookie_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session_cookie_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/session_cookie_test.go
+++ b/samlsp/session_cookie_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 func TestCookieSameSite(t *testing.T) {

--- a/samlsp/session_cookie_test.go
+++ b/samlsp/session_cookie_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session_cookie_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 const (

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session_jwt.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/session_jwt.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/util.go
+++ b/samlsp/util.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/util.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package samlsp
 

--- a/samlsp/util.go
+++ b/samlsp/util.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/samlsp/util.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package samlsp
 
 import (

--- a/samlsp/util.go
+++ b/samlsp/util.go
@@ -3,7 +3,7 @@ package samlsp
 import (
 	"io"
 
-	"github.com/crewjam/saml"
+	"github.com/grafana/saml"
 )
 
 func randomBytes(n int) []byte {

--- a/schema.go
+++ b/schema.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/schema.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/schema.go
+++ b/schema.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/schema.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/schema_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/schema_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/service_provider.go
+++ b/service_provider.go
@@ -23,8 +23,8 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/grafana/saml/logger"
+	"github.com/grafana/saml/xmlenc"
 )
 
 // NameIDFormat is the format of the id

--- a/service_provider.go
+++ b/service_provider.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/service_provider_signed.go
+++ b/service_provider_signed.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider_signed.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/service_provider_signed.go
+++ b/service_provider_signed.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider_signed.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/service_provider_signed_test.go
+++ b/service_provider_signed_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider_signed_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/service_provider_signed_test.go
+++ b/service_provider_signed_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider_signed_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/beevik/etree"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/testsaml"
+	"github.com/grafana/saml/testsaml"
 )
 
 type ServiceProviderTest struct {

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/service_provider_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/testsaml/parse.go
+++ b/testsaml/parse.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/testsaml/parse.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package testsaml contains functions for use in testing SAML requests and responses.
 package testsaml

--- a/testsaml/parse.go
+++ b/testsaml/parse.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/testsaml/parse.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package testsaml contains functions for use in testing SAML requests and responses.
 package testsaml
 

--- a/time.go
+++ b/time.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/time.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/time.go
+++ b/time.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/time.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import "time"

--- a/time_test.go
+++ b/time_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/time_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/time_test.go
+++ b/time_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/time_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/util.go
+++ b/util.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/util.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package saml
 
 import (

--- a/util.go
+++ b/util.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/util.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package saml
 

--- a/xmlenc/cbc.go
+++ b/xmlenc/cbc.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/cbc.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/cbc.go
+++ b/xmlenc/cbc.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/cbc.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/decrypt.go
+++ b/xmlenc/decrypt.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/decrypt.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/decrypt.go
+++ b/xmlenc/decrypt.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/decrypt.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/decrypt_test.go
+++ b/xmlenc/decrypt_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/decrypt_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/decrypt_test.go
+++ b/xmlenc/decrypt_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/decrypt_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/digest.go
+++ b/xmlenc/digest.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/digest.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/digest.go
+++ b/xmlenc/digest.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/digest.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/encrypt_test.go
+++ b/xmlenc/encrypt_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/encrypt_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/encrypt_test.go
+++ b/xmlenc/encrypt_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/encrypt_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/fuzz.go
+++ b/xmlenc/fuzz.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/fuzz.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/fuzz.go
+++ b/xmlenc/fuzz.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/fuzz.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/fuzz_test.go
+++ b/xmlenc/fuzz_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/fuzz_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 //go:build gofuzz
 // +build gofuzz

--- a/xmlenc/fuzz_test.go
+++ b/xmlenc/fuzz_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/fuzz_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 //go:build gofuzz
 // +build gofuzz
 

--- a/xmlenc/gcm.go
+++ b/xmlenc/gcm.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/gcm.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/gcm.go
+++ b/xmlenc/gcm.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/gcm.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/pubkey.go
+++ b/xmlenc/pubkey.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/pubkey.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (

--- a/xmlenc/pubkey.go
+++ b/xmlenc/pubkey.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/pubkey.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/xmlenc.go
+++ b/xmlenc/xmlenc.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/xmlenc.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 // Package xmlenc is a partial implementation of the xmlenc standard
 // as described in https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/Overview.html.

--- a/xmlenc/xmlenc.go
+++ b/xmlenc/xmlenc.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/xmlenc.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 // Package xmlenc is a partial implementation of the xmlenc standard
 // as described in https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/Overview.html.
 // The purpose of this implementation is to support encrypted SAML assertions.

--- a/xmlenc/xmlenc_test.go
+++ b/xmlenc/xmlenc_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/xmlenc_test.go
 // Provenance-includes-license: BSD-2-Clause
-// Provenance-includes-copyright: Ross Kinder
+// Provenance-includes-copyright: 2015-2023 Ross Kinder
 
 package xmlenc
 

--- a/xmlenc/xmlenc_test.go
+++ b/xmlenc/xmlenc_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Provenance-includes-location: https://github.com/crewjam/saml/blob/a32b643a25a46182499b1278293e265150056d89/xmlenc/xmlenc_test.go
+// Provenance-includes-license: BSD-2-Clause
+// Provenance-includes-copyright: Ross Kinder
+
 package xmlenc
 
 import (


### PR DESCRIPTION
Basic rename so we can do `go get github.com/grafana/saml` and not have to replace it with the fork.