### PR TITLE
Bump golang.org/x/crypto to latest version and drop unsupported Go versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
+---
 version: 2
+
 updates:
-- package-ecosystem: gomod
+- package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: daily
+    interval: "weekly"
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    minor-actions-dependencies:
+      # GitHub Actions: Only group minor and patch updates (we want to carefully review major updates)
+      update-types: [minor, patch]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.2
+          version: v1.64.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19.x', '1.20.x', '1.21.x', '1.22.x' ]
+        go: [ '1.23.x', '1.24.x' ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -151,3 +151,7 @@ The SAML specification is a collection of PDFs (sadly):
 - [SAMLConformance](http://docs.oasis-open.org/security/saml/v2.0/saml-conformance-2.0-os.pdf) includes a support matrix for various parts of the protocol.
 
 [SAMLtest](https://samltest.id/) is a testing ground for SAML service and identity providers.
+
+## Security Issues
+
+Please refer to our [Security Policy](https://github.com/grafana/saml/security/policy) when reporting security issues.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,3 @@ The SAML specification is a collection of PDFs (sadly):
 - [SAMLConformance](http://docs.oasis-open.org/security/saml/v2.0/saml-conformance-2.0-os.pdf) includes a support matrix for various parts of the protocol.
 
 [SAMLtest](https://samltest.id/) is a testing ground for SAML service and identity providers.
-
-## Security Issues
-
-Please do not report security issues in the issue tracker. Rather, please contact me directly at ross@kndr.org ([PGP Key `78B6038B3B9DFB88`](https://keybase.io/crewjam)). If your issue is *not* a security issue, please use the issue tracker so other contributors can help.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/saml
 
-go 1.19
+go 1.23.0
 
 require (
 	github.com/beevik/etree v1.2.0
@@ -13,7 +13,7 @@ require (
 	github.com/russellhaering/goxmldsig v1.4.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zenazn/goji v1.0.1
-	golang.org/x/crypto v0.31.0
+	golang.org/x/crypto v0.35.0
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/zenazn/goji v1.0.1 h1:4lbD8Mx2h7IvloP7r2C0D6ltZP6Ufip8Hn0wmSK5LR8=
 github.com/zenazn/goji v1.0.1/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
+golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=


### PR DESCRIPTION
This is a fix for [CVE-2025-22869](https://github.com/golang/go/issues/71931).

**Changes**
- This version of `golang.org/x/crypto` requires Go at least 1.23, so we need to bump our `go.mod` version as well. This makes sense, as Go 1.22 and older are no longer supported.

- Also means we run the CI with only the supported versions of Go (1.23.x and 1.24.x).

- I bumped the `golangci-lint` version because I remember having some issues in the migration of Go 1.19 to 1.20 or 1.20 to 1.21 where the linter would be extremely slow, so bumping to the latest and greatest to avoid hitting that.

- Finally, adding a directive in the Dependabot config so that we get action updates as well to keep our 3rdparty actions up-to-date.
