### PR TITLE
SLO: Validate signature on logout requests

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -333,6 +333,10 @@ func (sp *ServiceProvider) GetSLOBindingLocation(binding string) string {
 	return ""
 }
 
+// errNoIDPSigningCert is returned by getIDPSigningCerts when the IDP metadata
+// does not contain any signing certificate.
+var errNoIDPSigningCert = errors.New("cannot find any signing certificate in the IDP SSO descriptor")
+
 // getIDPSigningCerts returns the certificates which we can use to verify things
 // signed by the IDP in PEM format, or nil if no such certificate is found.
 func (sp *ServiceProvider) getIDPSigningCerts() ([]*x509.Certificate, error) {
@@ -354,7 +358,7 @@ func (sp *ServiceProvider) getIDPSigningCerts() ([]*x509.Certificate, error) {
 	}
 
 	if len(certStrs) == 0 {
-		return nil, errors.New("cannot find any signing certificate in the IDP SSO descriptor")
+		return nil, errNoIDPSigningCert
 	}
 
 	certs := make([]*x509.Certificate, len(certStrs))
@@ -1096,7 +1100,7 @@ func (sp *ServiceProvider) validateSignature(el *etree.Element) error {
 
 	certs, err := sp.getIDPSigningCerts()
 	if err != nil {
-		return fmt.Errorf("cannot validate signature on %s: %v", el.Tag, err)
+		return fmt.Errorf("cannot validate signature on %s: %w", el.Tag, err)
 	}
 
 	certificateStore := dsig.MemoryX509CertificateStore{
@@ -1520,6 +1524,59 @@ func (sp *ServiceProvider) ValidateLogoutResponseForm(postFormData string) error
 		return retErr
 	}
 	return sp.validateLogoutResponse(&resp)
+}
+
+// ParseLogoutRequestForm parses and validates a LogoutRequest received via the
+// HTTP-POST binding, returning the parsed LogoutRequest when it is valid.
+//
+// It mirrors ValidateLogoutResponseForm: the request is base64 decoded, checked
+// for well-formed XML, and its enveloped XML-DSig signature is verified against
+// the IDP signing certificates from metadata.
+//
+// When the IDP metadata does not contain any signing certificate, signature
+// validation is skipped. This graceful fallback is intentional: SAML SLO
+// deployments generally configure certificate signing, so the blast radius is
+// minimal, and it preserves interoperability with IDPs that advertise no
+// signing certificate.
+func (sp *ServiceProvider) ParseLogoutRequestForm(postFormData string) (*LogoutRequest, error) {
+	retErr := &InvalidResponseError{
+		Now: TimeNow(),
+	}
+
+	rawRequestBuf, err := base64.StdEncoding.DecodeString(postFormData)
+	if err != nil {
+		retErr.PrivateErr = fmt.Errorf("unable to parse base64: %s", err)
+		return nil, retErr
+	}
+	retErr.Response = string(rawRequestBuf)
+
+	if err := xrv.Validate(bytes.NewReader(rawRequestBuf)); err != nil {
+		retErr.PrivateErr = fmt.Errorf("request contains invalid XML: %s", err)
+		return nil, retErr
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(rawRequestBuf); err != nil {
+		retErr.PrivateErr = err
+		return nil, retErr
+	}
+
+	// Skip signature validation only when no IDP signing certificate is
+	// configured in metadata. Any other error from getIDPSigningCerts (e.g. an
+	// unparseable certificate) is surfaced by validateSignature below.
+	if _, err := sp.getIDPSigningCerts(); !errors.Is(err, errNoIDPSigningCert) {
+		if err := sp.validateSignature(doc.Root()); err != nil {
+			retErr.PrivateErr = err
+			return nil, retErr
+		}
+	}
+
+	var req LogoutRequest
+	if err := unmarshalElement(doc.Root(), &req); err != nil {
+		retErr.PrivateErr = err
+		return nil, retErr
+	}
+	return &req, nil
 }
 
 // ValidateLogoutResponseRedirect returns a nil error if the logout response is valid.

--- a/service_provider_signed_test.go
+++ b/service_provider_signed_test.go
@@ -9,9 +9,12 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/xml"
+	"errors"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/beevik/etree"
 	dsig "github.com/russellhaering/goxmldsig"
 	"gotest.tools/assert"
 	"gotest.tools/golden"
@@ -122,4 +125,114 @@ func TestInvalidSignatureAlgorithm(t *testing.T) {
 
 	err = s.validateQuerySig(query)
 	assert.Error(t, err, "unsupported signature algorithm: http://www.w3.org/2000/09/xmldsig#rsa-sha384")
+}
+
+// newSLOTestServiceProvider returns a ServiceProvider whose signing key/cert
+// matches the signing certificate advertised in the IDP metadata, so that
+// LogoutRequests signed with the SP key validate against the IDP metadata.
+// The clock is pinned to a time within idp_cert.pem's validity window
+// (Oct 2013 - Oct 2014) so enveloped-signature cert validation passes.
+func newSLOTestServiceProvider(t *testing.T) *ServiceProvider {
+	TimeNow = func() time.Time {
+		return time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
+	Clock = dsig.NewFakeClockAt(TimeNow())
+
+	s := &ServiceProvider{
+		Key:             mustParsePrivateKey(golden.Get(t, "idp_key.pem")).(*rsa.PrivateKey),
+		Certificate:     mustParseCertificate(golden.Get(t, "idp_cert.pem")),
+		MetadataURL:     mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
+		AcsURL:          mustParseURL("https://15661444.ngrok.io/saml2/acs"),
+		SloURL:          mustParseURL("https://15661444.ngrok.io/saml2/slo"),
+		SignatureMethod: dsig.RSASHA1SignatureMethod,
+	}
+	err := xml.Unmarshal(golden.Get(t, "SP_IDPMetadata_signing"), &s.IDPMetadata)
+	assert.NilError(t, err)
+	return s
+}
+
+// encodeLogoutRequest serializes a LogoutRequest to the base64-encoded form
+// value expected by ParseLogoutRequestForm (HTTP-POST binding).
+func encodeLogoutRequest(t *testing.T, r *LogoutRequest) string {
+	doc := etree.NewDocument()
+	doc.SetRoot(r.Element())
+	buf, err := doc.WriteToBytes()
+	assert.NilError(t, err)
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// A LogoutRequest signed by the IDP must be accepted and parsed.
+func TestSPParseLogoutRequestFormValidSignature(t *testing.T) {
+	s := newSLOTestServiceProvider(t)
+
+	req, err := s.MakeLogoutRequest(s.SloURL.String(), "user@example.com", "session-123")
+	assert.NilError(t, err)
+	assert.Check(t, req.Signature != nil, "expected request to be signed")
+
+	parsed, err := s.ParseLogoutRequestForm(encodeLogoutRequest(t, req))
+	assert.NilError(t, err)
+	assert.Equal(t, "user@example.com", parsed.NameID.Value)
+	assert.Equal(t, "session-123", parsed.SessionIndex.Value)
+}
+
+// An unsigned LogoutRequest must be rejected when the IDP metadata advertises a
+// signing certificate. This is the core of the fix: unsigned requests are no
+// longer trusted.
+func TestSPParseLogoutRequestFormUnsignedRejected(t *testing.T) {
+	s := newSLOTestServiceProvider(t)
+
+	// Build an unsigned request using an SP without a SignatureMethod.
+	unsignedSP := *s
+	unsignedSP.SignatureMethod = ""
+	req, err := unsignedSP.MakeLogoutRequest(s.SloURL.String(), "user@example.com", "")
+	assert.NilError(t, err)
+	assert.Check(t, req.Signature == nil, "expected request to be unsigned")
+
+	_, err = s.ParseLogoutRequestForm(encodeLogoutRequest(t, req))
+	assert.Check(t, err != nil, "expected unsigned request to be rejected")
+
+	var ivr *InvalidResponseError
+	assert.Check(t, errors.As(err, &ivr), "expected InvalidResponseError, got %T", err)
+	assert.Check(t, errors.Is(ivr.PrivateErr, errSignatureElementNotPresent),
+		"expected missing-signature error, got %v", ivr.PrivateErr)
+}
+
+// A LogoutRequest whose contents are altered after signing must be rejected.
+func TestSPParseLogoutRequestFormTamperedRejected(t *testing.T) {
+	s := newSLOTestServiceProvider(t)
+
+	req, err := s.MakeLogoutRequest(s.SloURL.String(), "user@example.com", "session-123")
+	assert.NilError(t, err)
+
+	// Tamper with the NameID after the signature was computed.
+	doc := etree.NewDocument()
+	doc.SetRoot(req.Element())
+	nameIDEl := doc.Root().FindElement("//NameID")
+	assert.Check(t, nameIDEl != nil, "expected NameID element")
+	nameIDEl.SetText("attacker@example.com")
+	buf, err := doc.WriteToBytes()
+	assert.NilError(t, err)
+
+	_, err = s.ParseLogoutRequestForm(base64.StdEncoding.EncodeToString(buf))
+	assert.Check(t, err != nil, "expected tampered request to be rejected")
+}
+
+// When the IDP metadata advertises no signing certificate, signature validation
+// is skipped and an unsigned request is accepted.
+func TestSPParseLogoutRequestFormNoSigningCertSkipsValidation(t *testing.T) {
+	s := newSLOTestServiceProvider(t)
+
+	req, err := s.MakeLogoutRequest(s.SloURL.String(), "user@example.com", "")
+	assert.NilError(t, err)
+	req.Signature = nil // ensure the request is unsigned
+
+	// Replace the metadata with one that has no signing certificate.
+	noCertSP := *s
+	noCertSP.IDPMetadata = &EntityDescriptor{}
+	_, err = noCertSP.getIDPSigningCerts()
+	assert.Check(t, errors.Is(err, errNoIDPSigningCert), "expected no-signing-cert metadata")
+
+	parsed, err := noCertSP.ParseLogoutRequestForm(encodeLogoutRequest(t, req))
+	assert.NilError(t, err)
+	assert.Equal(t, "user@example.com", parsed.NameID.Value)
 }


### PR DESCRIPTION
## What

Add `ServiceProvider.ParseLogoutRequestForm` to parse and validate SAML `LogoutRequest` messages received over the HTTP-POST binding. The enveloped XML-DSig signature is verified against the IdP signing certificates from metadata before the request is unmarshaled, so unsigned or tampered logout requests are rejected.

The flow mirrors the existing `ValidateLogoutResponseForm` and reuses `validateSignature()` and `getIDPSigningCerts()`. When the IdP metadata advertises no signing certificate, signature validation is skipped to preserve interoperability with IdPs that do not publish one.

## Why

Incoming Single Logout `LogoutRequest` messages were not signature-validated, so a forged or unsigned request could be used to terminate a user's session. This adds signature validation at the library level.

## Test plan

New unit tests in `service_provider_signed_test.go` cover:
- a valid signed request is accepted
- an unsigned request is rejected when a signing certificate is configured
- a request tampered with after signing is rejected
- signature validation is skipped when metadata advertises no signing certificate

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.